### PR TITLE
Fix colons breaking YAML validation in Polish translation

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -194,7 +194,7 @@ pl:
       Zobacz https://docs.plausible.io/add-website.
 
     # Zaawansowane: Niestandardowe wydarzenia, linki wychodzące
-    ADVANCED: Zaawansowany:
+    ADVANCED: Zaawansowany
     ENABLE_CUSTOM_EVENT_TRACKING: Włączyć niestandardowe śledzenie zdarzeń?
     ENABLE_CUSTOM_EVENT_TRACKING_HELP: Zobacz https://docs.plausible.io/custom-event-goals.
     TRACK_CUSTOM: Tak

--- a/languages.yaml
+++ b/languages.yaml
@@ -201,7 +201,7 @@ pl:
     DONT_TRACK_CUSTOM: Nie
 
     ENABLE_OUTBOUND_LINK_TRACKING: Włączyć śledzenie linków wychodzących?
-    ENABLE_OUTBOUND_LINK_TRACKING_HELP: Patrz: https://docs.plausible.io/outbound-link-click-tracking.
+    ENABLE_OUTBOUND_LINK_TRACKING_HELP: "Patrz: https://docs.plausible.io/outbound-link-click-tracking."
     TRACK_OUTBOUND_OUTBOUND: Tak
     DONT_TRACK_OUTBOUND: Nie
 


### PR DESCRIPTION
Grav would complain about YAML file being incorrect because of line 204 in languages.yaml
added quotes to avoid this problem